### PR TITLE
Support Ruby 3.3 or higher

### DIFF
--- a/.circle.yml
+++ b/.circle.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.4.1-node-browsers
+       - image: cimg/ruby:3.3.10-browsers
     working_directory: ~/repo
     steps:
       - checkout

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'base64'
+  gem 'bigdecimal'
   gem 'dotenv'
+  gem 'rexml'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,49 +1,55 @@
 PATH
   remote: .
   specs:
-    ruby_coincheck_client (0.2.0)
+    ruby_coincheck_client (0.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
-    diff-lcs (1.3)
-    dotenv (2.2.1)
-    hashdiff (0.3.7)
-    public_suffix (3.0.1)
-    rake (10.4.2)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    diff-lcs (1.6.2)
+    dotenv (3.2.0)
+    hashdiff (1.2.1)
+    public_suffix (7.0.5)
+    rake (10.5.0)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
-    safe_yaml (1.0.4)
-    webmock (3.1.1)
-      addressable (>= 2.3.6)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.9)
+  base64
+  bigdecimal
+  bundler (~> 2.7)
   dotenv
   rake (~> 10.0)
+  rexml
   rspec
   ruby_coincheck_client!
   webmock
 
 BUNDLED WITH
-   1.16.0
+   2.7.2

--- a/ruby_coincheck_client.gemspec
+++ b/ruby_coincheck_client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+    raise "RubyGems 3.0 or newer is required to protect against public gem pushes."
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "~> 2.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
# Ruby 3.3以降のサポート対応

## 修正点

詳細は後述。

1. bundlerのバージョンアップ
2. bundled gemsとなった（なる予定も含む）gemをGemfileに明記
3. CircleCIにて使用するDocker Imageの修正

### 1. bundlerのバージョンアップ

現行のGemfile.lockで指定されている bundler 1.16.0 では [Ruby 3.2 にて廃止](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/#removed-methods) された `Kernel#untaint` メソッドを使用しており、bundle installに失敗する。

bundlerのバージョンはCIで使用している Docker image [cimg/ruby:3.3.10-browsers](https://hub.docker.com/r/cimg/ruby/tags?name=3.3.10-browsers) に合わせた。
上記イメージに含まれる各種ツールのバージョンは [CircleCI 公式ドキュメント](https://circleci.com/developer/images/image/cimg/ruby) を参照。

```
$ bundle install
... /ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-1.16.0/lib/bundler/shared_helpers.rb:266:in `search_up': undefined method `untaint' for an instance of String (NoMethodError)

      current  = File.expand_path(SharedHelpers.pwd).untaint
                                                    ^^^^^^^^
```

### 2. bundled gemsとなった（なる予定も含む）gemをGemfileに明記

* rexml: webmockにて使用する。[Ruby3.0で bundled gems 扱い](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/#other-notable-changes-since-27)
* base64, bigdecimal: rspecにて使用する。 [Ruby3.4で bundled gems 扱い](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#standard-library-updates)

### 3. CircleCIにて使用するDocker Imageの修正

現行の `circleci/ruby:2.4.1-node-browsers` は [legacy扱い](https://circleci.com/docs/guides/execution-managed/circleci-images/#legacy-image-tags-by-language) で非推奨となっていたため、CircleCI公式の推奨する [cimg/ruby](https://hub.docker.com/r/cimg/ruby) に差し替えた。

## テスト結果

Pass

```
$ bundle exec rspec

CoincheckClient
  #read_trades
    return status code 200
  #order_books
    return status code 200
  #read_rate
    return status code 200
  #read_balance
    return status code 200
  #read_positions
    return status code 200

RubyCoincheckClient
  has a version number

Finished in 0.01428 seconds (files took 0.16444 seconds to load)
6 examples, 0 failures
```
